### PR TITLE
Add “Licenses & certifications” as a target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "scrapedin",
-  "version": "1.0.20",
-  "description": "linkedin scraper for 2019 website",
+  "version": "1.0.21",
+  "description": "linkedin scraper for 2020 website",
   "keywords": [
     "linkedin",
-    "scraper"
+    "scraper",
+    "crawler"
   ],
   "main": "src/scrapedin.js",
   "scripts": {

--- a/src/company/company.js
+++ b/src/company/company.js
@@ -13,7 +13,7 @@ module.exports = async (browser, cookies, url, waitTimeToScrapMs = 500, puppetee
   if(url.includes('legacySchoolId=')){
       page = await openPage({ browser, cookies, url, puppeteerAuthenticate });
 
-      const aboutSelector = 'a[data-control-name=page_member_main_nav_about_tab]';
+      const aboutSelector = 'a[href$="/about/"]';
 
       company.url = page.url();
       

--- a/src/openPage.js
+++ b/src/openPage.js
@@ -10,8 +10,9 @@ const agents = [
   // "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36"
 ]
 
-module.exports = async ({ browser, cookies, url, puppeteerAuthenticate }) => {
+module.exports = ({ browser, cookies, url, puppeteerAuthenticate }) => new Promise( async (resolve, reject) => {
   const page = await browser.newPage()
+  page.on('error', err => {reject(err)})
 
   if (cookies) {
     await page.setCookie(...cookies)
@@ -29,5 +30,5 @@ module.exports = async ({ browser, cookies, url, puppeteerAuthenticate }) => {
 
   await page.goto(url)
 
-  return page
-}
+  resolve(page)
+})

--- a/src/profile/profileScraperTemplate.js
+++ b/src/profile/profileScraperTemplate.js
@@ -4,10 +4,10 @@ const template = {
   profile: {
     selector: '.pv-top-card',
     fields: {
-      name: `.pv-top-card--list:first-child li:first-child`,
-      headline: `h2`,
-      location: `.pv-top-card--list:last-child li:first-child`,
-      connections: `.pv-top-card--list:last-child li:nth-child(2)`,
+      name: `.text-heading-xlarge`,
+      headline: `.text-body-medium`,
+      location: `.pb2 .text-body-small`,
+      connections: `li.text-body-small`,
       imageurl: {
 		    selector: `img.pv-top-card__photo`,
         attribute: 'src'


### PR DESCRIPTION
It would be great to have the ability to search in the “Licenses & certifications” for a specific word.