### PR TITLE
Scroll the element to center before click

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Wagner Leonardi <leonardiwagner@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "puppeteer": "1.13.0",
+    "puppeteer": "1.20.0",
     "winston": "3.1.0"
   },
   "devDependencies": {

--- a/src/profile/seeMoreButtons.js
+++ b/src/profile/seeMoreButtons.js
@@ -30,6 +30,8 @@ const clickAll = async(page) => {
     for(let j = 0; j < elems.length; j++){
       const elem = elems[j]
       if (elem) {
+        await elem.evaluate(el => el.scrollIntoView({ block: "center" }))
+          .catch((e) => logger.warn(`couldn't scroll to ${button.selector}`))
         await elem.click()
           .catch((e) => logger.warn(`couldn't click on ${button.selector}, it's probably invisible`))
       }


### PR DESCRIPTION
This should prevent rare cases where the header overlaps the button and clicking the button redirects the page, aborting the whole scraping process.
Fixes #161